### PR TITLE
Allowing for Optional build-id Input

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
     const startedAt = BigInt(core.getInput('started-at', {required: true}));
     const endedAt = BigInt(core.getInput('ended-at'));
     const status = core.getInput('status', {required: true});
+    const buildId = core.getInput('build-id');
     const pipelineId = core.getInput('build-pipeline-id');
 
     const model = core.getInput('model', {required: true});
@@ -26,7 +27,7 @@ async function run(): Promise<void> {
 
     const emit = new Emit(apiKey, url, graph);
     if (model === BUILD) {
-      const build = makeBuildInfo(startedAt, endedAt, status, pipelineId);
+      const build = makeBuildInfo(startedAt, endedAt, status, buildId, pipelineId);
       await emit.build(build);
     } else {
       const deployment = makeDeploymentInfo(startedAt, status, endedAt);
@@ -41,13 +42,17 @@ function makeBuildInfo(
   startedAt: BigInt,
   endedAt: BigInt,
   status: string,
+  buildId?: string,
   pipelineId?: string
 ): Build {
   const repoName = getEnvVar('GITHUB_REPOSITORY');
   const splitRepo = repoName.split('/');
   const org = splitRepo[0];
   const repo = splitRepo[1];
-  const id = getEnvVar('GITHUB_RUN_ID');
+  const id = buildId
+    ? buildId
+    : getEnvVar('GITHUB_RUN_ID');
+
   const number = parseInt(getEnvVar('GITHUB_RUN_NUMBER'));
   const workflowName = getEnvVar('GITHUB_WORKFLOW');
   const pipeline = pipelineId


### PR DESCRIPTION
## Description

In order to ensure backward compatibility the code will continue to pull the `build-id` from the GITHUB_RUN_ID unless an override is manually passed into the action via the `build-id` input param.

## Things I need to figure out

What is the best way to test a GH action?

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## Related issues

https://github.com/faros-ai/tickets/issues/198

## Related PR

https://github.com/faros-ai/poseidon/pull/1274
