### PR TITLE
Switching to retry 502s from POST

### DIFF
--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -12,13 +12,13 @@ describe('axios', () => {
   });
   test('get resource with retry', async () => {
     const mock = nock(apiUrl)
-      .get('/hi')
+      .post('/hi')
       .reply(502)
-      .get('/hi')
+      .post('/hi')
       .reply(502)
-      .get('/hi')
+      .post('/hi')
       .reply(502)
-      .get('/hi')
+      .post('/hi')
       .reply(200, {tenantId: '1'});
     const client = makeAxiosInstanceWithRetry(
       {baseURL: apiUrl},
@@ -26,20 +26,20 @@ describe('axios', () => {
       3,
       100
     );
-    const res = await client.get('/hi');
+    const res = await client.post('/hi');
     expect(res.status).toBe(200);
     expect(res.data).toStrictEqual({tenantId: '1'});
     mock.done();
   });
   test('give up after a retry', async () => {
-    const mock = nock(apiUrl).get('/hi').reply(502).get('/hi').reply(404);
+    const mock = nock(apiUrl).post('/hi').reply(502).post('/hi').reply(404);
     const client = makeAxiosInstanceWithRetry(
       {baseURL: apiUrl},
       logger,
       1,
       100
     );
-    await expect(client.get('/hi')).rejects.toThrowError(
+    await expect(client.post('/hi')).rejects.toThrowError(
       'Request failed with status code 404'
     );
     mock.done();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import axios, {AxiosInstance, AxiosRequestConfig} from 'axios';
-import axiosRetry, {IAxiosRetryConfig} from 'axios-retry';
+import axiosRetry, {IAxiosRetryConfig, isRetryableError} from 'axios-retry';
 import pino from 'pino';
 
 export const DEFAULT_RETRIES = 3;
@@ -31,6 +31,7 @@ export function makeAxiosInstanceWithRetry(
 ): AxiosInstance {
   return makeAxiosInstance(config, {
     retries,
+    retryCondition: isRetryableError,
     retryDelay: (retryNumber, error) => {
       if (logger) {
         logger.warn(error, `Retry attempt ${retryNumber} of ${retries}`);


### PR DESCRIPTION
## Description

Should be retrying 502 responses from `POST`

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
