### PR TITLE
Include Repo in Pipeline name for Differentiation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,7 @@ function makeBuildInfo(
     startedAt,
     endedAt,
     status: toBuildStatus(status),
-    pipelineName: workflowName,
+    pipelineName: name,
     pipelineId: pipeline,
     serverUrl
   };


### PR DESCRIPTION
## Description

Currently, the name of the pipeline that is emitted to Faros is `workflowName` which is the name of the Github Action workflow. If you use the same workflow name across projects (i.e. `CI/CD`) the pipelines will be indistinguishable by name alone in the Faros UI. By switching `pipelineName` to name (`${repoName}_${workflowName}`) you can easily tell which repo and which workflow when attributing pipelines to teams in the UI.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
