### PR TITLE
Run on Node.js v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To report a code build to Faros specify `CI` in the `event` parameter and includ
 ```yaml
 - name: Report code build to Faros
   id: send-ci-event
-  uses: faros-ai/faros-cicd-github-action@v3.0.6
+  uses: faros-ai/faros-cicd-github-action@v3.0.7
   with:
     api-key: ${{ secrets.FAROS_API_KEY }}
     event: CI
@@ -30,7 +30,7 @@ To report an artifact deployment to Faros specify `CD` in the `event` parameter 
 ```yaml
 - name: Report deployment to Faros
   id: send-cd-event
-  uses: faros-ai/faros-cicd-github-action@v3.0.6
+  uses: faros-ai/faros-cicd-github-action@v3.0.7
   with:
     api-key: ${{ secrets.FAROS_API_KEY }}
     event: CD

--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ branding:
   icon: fast-forward
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Gets rid of these warnings:

<img width="1358" alt="warnings" src="https://github.com/faros-ai/faros-cicd-github-action/assets/6371196/0def1ea8-98f0-46fc-afd5-5f2f0f5e7e6d">

See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
