### PR TITLE
Add min-release-age for supply chain security

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm install
-      - run: |
-          npm run all
+      - run: npm install -g npm@11
+      - run: npm install
+      - run: npm run all
 
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install -g npm@11
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - run: npm install
       - run: npm run all
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "npm": ">=11.10.0"
+  },
   "dependencies": {
     "@actions/core": "^2.0.3"
   },


### PR DESCRIPTION
## Summary

Uses npm 11's `min-release-age` config to restrict dependency resolution to packages published at least 7 days ago. This is a lightweight supply chain security measure that helps protect against malicious packages by ensuring only packages that have survived a 7-day window are eligible for installation.

## Changes

- Adds `.npmrc` at the repo root with `min-release-age=7`

## Test plan

- [ ] Verify `npm install` completes successfully with the new config
- [ ] Confirm that newly published packages (less than 7 days old) are excluded from resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)