### PR TITLE
FAI-21111 | chore(ci): upgrade GitHub Actions to Node 24 and pin to commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'monthly'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - run: npm install
@@ -23,7 +23,7 @@ jobs:
       FAROS_API_URL: https://dev.api.faros.ai
       FAROS_DRY_RUN: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: ./
         name: Send CI event to Faros using commit


### PR DESCRIPTION
## Summary

GitHub is deprecating Node 20 as the runtime for JavaScript actions:

- **2026-06-02** — JS actions will be forced to Node 24 by default.
- **2026-09-16** — Node 20 will be removed from the runners.

See [the GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This PR moves every affected JS action to the lowest major that runs on Node 24, and pins **every** third-party action to a full 40-character commit SHA. Pinning to SHA is a SOC 2 / supply-chain control — it removes implicit trust that a mutable tag like `v6` will not be re-pointed at malicious code (see the March 2025 `tj-actions/changed-files` incident as a concrete example).

The trailing `# vX.Y.Z` comment is the convention Dependabot uses to bump both the SHA and the tag comment together.

## What changed

- All `actions/*`, `docker/*`, and third-party `uses:` lines in `.github/workflows/` rewritten to `<owner>/<name>@<sha> # <tag>`.
- `.github/dependabot.yml` added (or `github-actions` ecosystem appended) so SHA pins don't silently bit-rot.
- Faros-internal actions (`faros-ai/*`) are **not** touched — they're already SHA-pinned internally.
- Runtime `node-version:` inputs are **not** touched — those are separate from the action runtime and changing them can break builds. Reviewers should decide per-repo whether to also bump runtime Node.

## Caveats

A handful of third-party actions do not yet have a Node 24 release (`stefanzweifel/git-auto-commit-action`, `slackapi/slack-github-action`, `hashicorp/setup-terraform`, etc.). Those are still SHA-pinned for supply-chain hardening, but flagged in the trailing comment as needing replacement before **2026-09-16**.

## Test plan

- [ ] CI checks pass on this branch (no `Node.js 20 actions are deprecated` warnings in the run logs)
- [ ] Workflows that run rarely (release, scheduled) are triggered manually via `workflow_dispatch` to confirm they don't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)
